### PR TITLE
♻️ Change type hints to support versions older than Python 3.9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ build/
 __pycache__/
 .venv
 .coverage*
+venv/

--- a/fastapi_authorization/abac.py
+++ b/fastapi_authorization/abac.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from inspect import Parameter, Signature
-from typing import Any, Callable, Sequence
+from typing import Any, Callable, Sequence, Union, List, Any
 
 from fastapi import Depends, params
 
@@ -12,7 +12,7 @@ except ModuleNotFoundError:
 
 
 class ABAC:
-    def __init__(self, policies: list[Policy] | None = None) -> None:
+    def __init__(self, policies: Union[List[Policy], None] = None) -> None:
         self.policies = policies or []
 
     def add_policy(
@@ -22,6 +22,7 @@ class ABAC:
 
     def Permission(self, resource: str, action: str) -> params.Depends:
         current_policy = None
+        
         for policy in self.policies:
             if (resource, action) == policy:
                 current_policy = policy

--- a/fastapi_authorization/testing.py
+++ b/fastapi_authorization/testing.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import inspect
-from typing import Sequence
+from typing import Sequence, Union
 
 from fastapi import FastAPI
 from fastapi.routing import APIRoute
@@ -11,7 +11,7 @@ from fastapi_authorization.rbac import RBAC
 
 
 def auto_test_protected_endpoints(
-    app: FastAPI, auth: RBAC | ABAC, exclude: Sequence[str] = ()
+    app: FastAPI, auth: Union[RBAC, ABAC], exclude: Sequence[str] = ()
 ) -> None:
     module_name = f"fastapi_authorization.{auth.__class__.__name__.lower()}"
 

--- a/fastapi_authorization/utils.py
+++ b/fastapi_authorization/utils.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
-from typing import Type, TypeVar
+from typing import Type, TypeVar, Union, List
+
 
 T = TypeVar("T")
 
-
-def normalize_list(items: list[str | T], type_: Type[T]) -> list[T]:
+def normalize_list(items: List[Union[str, T]], type_: Type[T]) -> List[T]:
     """Normalize a list of items to a list of the specified type.
 
     This solution assumes that T is instantiable with a single string argument.


### PR DESCRIPTION
I tested these changes for Python 3.8.10, but I believe they work for 3.7 also